### PR TITLE
[NOJIRA] fix the annoying nova client deprecation warning

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -117,7 +117,7 @@ regions = tuple()
 services = tuple()
 
 _client_classes = {
-        "compute": _cs_client.get_client_class(_cs_max_version),
+        "compute": _cs_client.Client(_cs_max_version),
         "cdn": CloudCDNClient,
         "object_store": StorageClient,
         "database": CloudDatabaseClient,

--- a/pyrax/version.py
+++ b/pyrax/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-version = "1.9.9"
+version = "1.9.10"


### PR DESCRIPTION
As it says on the tin, fix this deprecation warning:
```
/usr/local/lib/python3.6/dist-packages/novaclient/client.py:831: UserWarning: 'get_client_class' is deprecated. Please use `novaclient.client.Client` instead.
  warnings.warn(_LW("'get_client_class' is deprecated. "
```